### PR TITLE
P800 warning logs fix

### DIFF
--- a/app/uk/gov/hmrc/mobilepaye/domain/taxcalc/P800Status.scala
+++ b/app/uk/gov/hmrc/mobilepaye/domain/taxcalc/P800Status.scala
@@ -24,20 +24,21 @@ object P800Status {
   case object Underpaid extends P800Status
   case object Overpaid extends P800Status
   case object NotReconciled extends P800Status
+  case object NotSupported extends P800Status
 
   implicit val format: Format[P800Status] = new Format[P800Status] {
 
     override def writes(o: P800Status): JsValue = o match {
       case Underpaid     => JsString("underpaid")
       case Overpaid      => JsString("overpaid")
-      case NotReconciled => JsString("not_reconciled")
+      case NotSupported  => JsString("not_supported")
     }
 
     override def reads(json: JsValue): JsResult[P800Status] =
       json.validate[String].map {
         case "underpaid"      => Underpaid
         case "overpaid"       => Overpaid
-        case "not_reconciled" => NotReconciled
+        case _                => NotSupported
       }
   }
 }

--- a/it/LiveMobilePayeControllerISpec.scala
+++ b/it/LiveMobilePayeControllerISpec.scala
@@ -456,7 +456,7 @@ class LiveMobilePayeControllerISpec extends BaseISpec with Injecting {
     }
   }
 
-  "return OK and no P800 when type is not overpaid" in {
+  "return OK and no P800 when type is underpaid" in {
     stubForShutteringDisabled
     grantAccess(nino)
     personalDetailsAreFound(nino, person)
@@ -465,6 +465,21 @@ class LiveMobilePayeControllerISpec extends BaseISpec with Injecting {
     stubForPensions(nino, pensionIncomeSource)
     stubForEmployments(nino, employmentIncomeSource)
     taxCalcWithInstantDate(nino, currentTaxYear, LocalDate.now, yearTwoType = "underpaid")
+
+    val response = await(requestWithCurrentYearAsCurrent.get())
+    response.status                                  shouldBe 200
+    Json.parse(response.body).as[MobilePayeResponse] shouldBe fullMobilePayeResponse
+  }
+
+  "return OK and no P800 when type is not overpaid" in {
+    stubForShutteringDisabled
+    grantAccess(nino)
+    personalDetailsAreFound(nino, person)
+    nonTaxCodeIncomeIsFound(nino, nonTaxCodeIncome)
+    taxAccountSummaryIsFound(nino, taxAccountSummary)
+    stubForPensions(nino, pensionIncomeSource)
+    stubForEmployments(nino, employmentIncomeSource)
+    taxCalcWithInstantDate(nino, currentTaxYear, LocalDate.now, yearTwoType = "balanced")
 
     val response = await(requestWithCurrentYearAsCurrent.get())
     response.status                                  shouldBe 200


### PR DESCRIPTION
Added a catch all to the taxcalc response to handle statuses we are not interested in without filling up the logs with warnings